### PR TITLE
Include smaller US states

### DIFF
--- a/newgraph.js
+++ b/newgraph.js
@@ -397,14 +397,15 @@ left = () => {
 
 buildTable = () => {
   // the regions we want to list must be present in the population data and
-  // have greater than 1m residents
+  // have greater than 1m residents or be a US state/territory with at least 10k
   const inactiveRegions = d3
     .keys(rawData.data)
     .filter(
       (d) =>
         activeRegions.indexOf(d) == -1 &&
         capita.hasOwnProperty(d) &&
-        capita[d] > 1000000
+        capita[d] > 10000 &&
+        ( capita[d] > 1000000 || d.indexOf(", US") != -1 )
     );
 
   const type = plotType();


### PR DESCRIPTION
This adds smaller US states that were excluded due to their lower population:
- District of Columbia (DC)
- Alaska
- Delaware
- North Dakota
- South Dakota
- Vermont
- Wyoming