### PR TITLE
Make hover box display over alphabetical order link

### DIFF
--- a/static/base.css
+++ b/static/base.css
@@ -22,6 +22,7 @@ article {
   display: none;
   background: white;
   border: 1px solid #232323;
+  z-index: 2;
 }
 .suboption {
   margin-left: 10px;


### PR DESCRIPTION
The hover box on the graph displayed over everything except the "alphabetical order" option. This bumps the z-index up to display over that text.